### PR TITLE
Various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@
 language: cpp
 
 compiler:
-  - clang++
+  - clang
+  - gcc
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ dist: bionic
 
 before_install:
   - sudo apt-get -y install ninja-build
-  - mkdir -p build/linx64-RelWithDebInfo
 
 script:
-  - cd build/linx64-RelWithDebInfo
-  - cmake --DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja ../../
-  - cmake --build .
+  - python3 builder.py --configuration RelWithDebInfo --arch x64 --run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_install:
   - sudo apt-get -y install ninja-build
 
 script:
-  - python3 builder.py --configuration RelWithDebInfo --arch x64 --run-tests
+  - python3 builder.py --run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,10 @@ before_install:
   - sudo apt-get -y install ninja-build
 
 env:
-  - CONFIGURATION=Debug
-  - CONFIGURATION=RelWithDebInfo
-
-env:
-  - ARCH=x64
-  - ARCH=x86
+  - CONFIGURATION=Debug ARCH=x86
+  - CONFIGURATION=RelWithDebInfo ARCH=x86
+  - CONFIGURATION=Debug ARCH=x64
+  - CONFIGURATION=RelWithDebInfo ARCH=x64
 
 script:
   - python3 builder.py --configuration $CONFIGURATION --arch $ARCH --run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ sudo: required
 dist: bionic
 
 before_install:
-  - sudo apt-get -y install ninja-build
+  - sudo apt-get -y install ninja-build g++-multilib
 
 env:
   - CONFIGURATION=Debug ARCH=x86

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,13 @@ dist: bionic
 before_install:
   - sudo apt-get -y install ninja-build
 
+env:
+  - CONFIGURATION=Debug
+  - CONFIGURATION=RelWithDebInfo
+
+env:
+  - ARCH=x64
+  - ARCH=x86
+
 script:
-  - python3 builder.py --run-tests
+  - python3 builder.py --configuration $CONFIGURATION --arch $ARCH --run-tests

--- a/README.md
+++ b/README.md
@@ -91,9 +91,58 @@ Physical memory:
 
 ### Linux
 
-You can build it via the command line using `cmake` (also works in WSL):
+You can build it via the command line using `builder.py` or invoking `cmake` yourself (also works in WSL):
 
 ```text
+over@oof:/kdmp-parser$ python3 builder.py -h
+usage: Build and run test [-h] [--run-tests]
+                          [--configuration {Debug,RelWithDebInfo}]
+                          [--arch {x64,x86}]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --run-tests
+  --configuration {Debug,RelWithDebInfo}
+  --arch {x64,x86}
+
+over@oof:/kdmp-parser$ python3 builder.py --configuration Debug
+-- The C compiler identification is GNU 7.4.0
+-- The CXX compiler identification is GNU 7.4.0
+-- Check for working C compiler: /usr/bin/cc
+-- Check for working C compiler: /usr/bin/cc -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Check for working CXX compiler: /usr/bin/c++
+-- Check for working CXX compiler: /usr/bin/c++ -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /kdmp-parser/build/linx64-Debug
+[6/6] Linking CXX executable ../../bin/linx64-Debug/testapp
+-- The C compiler identification is GNU 7.4.0
+-- The CXX compiler identification is GNU 7.4.0
+-- Check for working C compiler: /usr/bin/cc
+-- Check for working C compiler: /usr/bin/cc -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Check for working CXX compiler: /usr/bin/c++
+-- Check for working CXX compiler: /usr/bin/c++ -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /kdmp-parser/build/linx86-Debug
+[6/6] Linking CXX executable ../../bin/linx86-Debug/testapp
+
 over@oof:/kdmp-parser/$ cd build/
 over@oof:/kdmp-parser/build$ mkdir linx64-RelWithDebInfo/
 over@oof:/kdmp-parser/build$ cd linx64-RelWithDebInfo/
@@ -121,9 +170,47 @@ over@oof:/kdmp-parser/build/linx64-RelWithDebInfo$ cmake --build .
 
 ### Windows
 
-You can build it using [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/) by either using the "Open the folder" option or via command line using `cmake` (from a Visual Studio shell):
+You can build it using [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/) by either using the "Open the folder" option or via command line using `builder.py` or `cmake` directly (from a Visual Studio shell):
 
 ```text
+kdmp-parser>python builder.py --configuration Debug
+-- The C compiler identification is MSVC 19.25.28614.0
+-- The CXX compiler identification is MSVC 19.25.28614.0
+-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe
+-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe
+-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- Configuring done
+-- Generating done
+-- Build files have been written to: kdmp-parser/build/x64-Debug
+[6/6] Linking CXX executable ..\..\bin\x64-Debug\testapp.exe
+-- The C compiler identification is MSVC 19.25.28614.0
+-- The CXX compiler identification is MSVC 19.25.28614.0
+-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx86/x86/cl.exe
+-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx86/x86/cl.exe -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx86/x86/cl.exe
+-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx86/x86/cl.exe -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- Configuring done
+-- Generating done
+-- Build files have been written to: kdmp-parser/build/x86-Debug
+[6/6] Linking CXX executable ..\..\bin\x86-Debug\testapp.exe
+
 kdmp-parser>cd build
 kdmp-parser\build>mkdir x64-RelWithDebInfo
 kdmp-parser\build>cd x64-RelWithDebInfo
@@ -173,43 +260,55 @@ Examples:
 
 ## Testing
 
-You can run `run-tests.py` from a Visual Studio command prompt to run basic tests. First, it builds every platform / configuration combination via `msbuild`, then it downloads two kernel dumps (one full dump and one bitmap dump) and runs every flavor of `test.exe` against the dumps.
+You can run `builder.py` with the `--run-tests` flag to run basic tests. First, it builds the matrix, then it downloads two kernel dumps (one full dump and one bitmap dump) and runs every flavor of the `testapp` application against the dumps.
 
 ```text
-kdmp-parser>python run-tests.py
+kdmp-parser>python builder.py --configuration RelWithDebInfo --run-tests
+-- The C compiler identification is MSVC 19.25.28614.0
+-- The CXX compiler identification is MSVC 19.25.28614.0
+-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe
+-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe
+-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx64/x64/cl.exe -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
 -- Configuring done
 -- Generating done
--- Build files have been written to: C:/work/codes/kdmp-parser/build/x64-Debug
-[4/4] Linking CXX executable ..\..\bin\x64-Debug\parser.exe
+-- Build files have been written to: kdmp-parser/build/x64-RelWithDebInfo
+[6/6] Linking CXX executable ..\..\bin\x64-RelWithDebInfo\parser.exe
+-- The C compiler identification is MSVC 19.25.28614.0
+-- The CXX compiler identification is MSVC 19.25.28614.0
+-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx86/x86/cl.exe
+-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx86/x86/cl.exe -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx86/x86/cl.exe
+-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.25.28610/bin/Hostx86/x86/cl.exe -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
 -- Configuring done
 -- Generating done
--- Build files have been written to: C:/work/codes/kdmp-parser/build/x64-RelWithDebInfo
-[4/4] Linking CXX executable ..\..\bin\x64-RelWithDebInfo\test.exe
--- Configuring done
--- Generating done
--- Build files have been written to: C:/work/codes/kdmp-parser/build/x86-Debug
-[4/4] Linking CXX executable ..\..\bin\x86-Debug\test.exe
--- Configuring done
--- Generating done
--- Build files have been written to: C:/work/codes/kdmp-parser/build/x86-RelWithDebInfo
-[4/4] Linking CXX executable ..\..\bin\x86-RelWithDebInfo\test.exe
+-- Build files have been written to: kdmp-parser/build/x86-RelWithDebInfo
+[6/6] Linking CXX executable ..\..\bin\x86-RelWithDebInfo\testapp.exe
 Downloading https://github.com/0vercl0k/kdmp-parser/releases/download/v0.1/testdatas.zip..
-Successfully downloaded the test datas in C:\Users\over\AppData\Local\Temp\tmphnjja5f5, extracting..
-Launching "bin\x64-Debug\test.exe C:\Users\over\AppData\Local\Temp\full.dmp"..
+Successfully downloaded the test datas in C:\Users\over\AppData\Local\Temp\tmp5o25eqtd, extracting..
+Launching "bin\x64-RelWithDebInfo\testapp C:\Users\over\AppData\Local\Temp\full.dmp"..
 GPRs matches the testdatas.
-Launching "bin\x64-RelWithDebInfo\test.exe C:\Users\over\AppData\Local\Temp\full.dmp"..
+Launching "bin\x86-RelWithDebInfo\testapp C:\Users\over\AppData\Local\Temp\full.dmp"..
 GPRs matches the testdatas.
-Launching "bin\x86-Debug\test.exe C:\Users\over\AppData\Local\Temp\full.dmp"..
+Launching "bin\x64-RelWithDebInfo\testapp C:\Users\over\AppData\Local\Temp\bmp.dmp"..
 GPRs matches the testdatas.
-Launching "bin\x86-RelWithDebInfo\test.exe C:\Users\over\AppData\Local\Temp\full.dmp"..
-GPRs matches the testdatas.
-Launching "bin\x64-Debug\test.exe C:\Users\over\AppData\Local\Temp\bmp.dmp"..
-GPRs matches the testdatas.
-Launching "bin\x64-RelWithDebInfo\test.exe C:\Users\over\AppData\Local\Temp\bmp.dmp"..
-GPRs matches the testdatas.
-Launching "bin\x86-Debug\test.exe C:\Users\over\AppData\Local\Temp\bmp.dmp"..
-GPRs matches the testdatas.
-Launching "bin\x86-RelWithDebInfo\test.exe C:\Users\over\AppData\Local\Temp\bmp.dmp"..
+Launching "bin\x86-RelWithDebInfo\testapp C:\Users\over\AppData\Local\Temp\bmp.dmp"..
 GPRs matches the testdatas.
 All good!
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ platform:
 clone_folder: c:\projects\kdmp-parser
 
 build_script:
-  - cmd: C:\Python38-x64\python.exe builder.py --configuration %configuration% --arch %arch% --run-tests
+  - cmd: C:\Python38-x64\python.exe builder.py --configuration %configuration% --arch %platform% --run-tests
 
 after_build:
   - cmd: cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,19 +14,12 @@ platform:
 
 clone_folder: c:\projects\kdmp-parser
 
-before_build:
-  - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %platform%
-  - cmd: cd build
-  - cmd: mkdir %platform%-%configuration%
-  - cmd: cmake -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=%APPVEYOR_BUILD_FOLDER%\bin\%platform%-%configuration% -DCMAKE_BUILD_TYPE=%configuration% -GNinja %APPVEYOR_BUILD_FOLDER%
-
 build_script:
-  - cmd: cmake --build .
+  - cmd: python3 builder.py --configuration %configuration% --arch %arch% --run-tests
 
 after_build:
   - cmd: cd %APPVEYOR_BUILD_FOLDER%
   - cmd: 7z a -t7z kdmp-parser-%platform%.%configuration%.7z bin\%platform%-%configuration%\*
-  - cmd: C:\Python38-x64\python.exe run-tests.py
   - cmd: chdir
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ platform:
 clone_folder: c:\projects\kdmp-parser
 
 build_script:
-  - cmd: python3 builder.py --configuration %configuration% --arch %arch% --run-tests
+  - cmd: C:\Python38-x64\python.exe builder.py --configuration %configuration% --arch %arch% --run-tests
 
 after_build:
   - cmd: cd %APPVEYOR_BUILD_FOLDER%

--- a/src/lib/kdmp-parser-structs.h
+++ b/src/lib/kdmp-parser-structs.h
@@ -72,7 +72,8 @@ struct DisplayUtils {
   DisplayField(Prefix + 2, #FieldName, this, &FieldName)
 
 #define DISPLAY_FIELD_OFFSET(FieldName)                                        \
-  DisplayHeader(Prefix + 2, #FieldName, this, &FieldName)
+  DisplayHeader(Prefix + 2, #FieldName, this, &FieldName);                     \
+  printf("\n")
 
   //
   // What follows are all the specializations we support. Basically,

--- a/src/lib/kdmp-parser-structs.h
+++ b/src/lib/kdmp-parser-structs.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "platform.h"
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -59,8 +60,8 @@ struct DisplayUtils {
 
   void DisplayHeader(const uint32_t Prefix, const char *FieldName,
                      const void *This, const void *Field) const {
-    printf("%*s+0x%04llx: %-25s", Prefix, "", OffsetFromThis(This, Field),
-           FieldName);
+    printf("%*s+0x%04" PRIx64 ": %-25s", Prefix, "",
+           OffsetFromThis(This, Field), FieldName);
   }
 
   //
@@ -99,13 +100,13 @@ struct DisplayUtils {
   void DisplayField(const uint32_t Prefix, const char *FieldName,
                     const void *This, const uint64_t *Field) const {
     DisplayHeader(Prefix, FieldName, This, Field);
-    printf(": 0x%016llx.\n", *Field);
+    printf(": 0x%016" PRIx64 ".\n", *Field);
   }
 
   void DisplayField(const uint32_t Prefix, const char *FieldName,
                     const void *This, const uint128_t *Field) const {
     DisplayHeader(Prefix, FieldName, This, Field);
-    printf(": 0x%016llx%016llx.\n", Field->High, Field->Low);
+    printf(": 0x%016" PRIx64 "%016" PRIx64 ".\n", Field->High, Field->Low);
   }
 
   void DisplayField(const uint32_t Prefix, const char *FieldName,
@@ -180,7 +181,7 @@ struct KDMP_PARSER_PHYSMEM_DESC : public DisplayUtils {
   }
 
   bool LooksGood() const {
-    if (NumberOfRuns == 'EGAP' || NumberOfPages == 0x4547415045474150ULL) {
+    if (NumberOfRuns == 0x45474150 || NumberOfPages == 0x4547415045474150ULL) {
       return false;
     }
 
@@ -192,8 +193,8 @@ static_assert(sizeof(KDMP_PARSER_PHYSMEM_DESC) == 0x20,
               "PHYSICAL_MEMORY_DESCRIPTOR's size looks wrong.");
 
 struct KDMP_PARSER_BMP_HEADER64 : public DisplayUtils {
-  static const uint32_t ExpectedSignature = 'PMDS';
-  static const uint32_t ExpectedValidDump = 'PMUD';
+  static const uint32_t ExpectedSignature = 0x504D4453; // 'PMDS'
+  static const uint32_t ExpectedValidDump = 0x504D5544; // 'PMUD'
 
   //
   // Should be FDMP.
@@ -586,8 +587,8 @@ static_assert(sizeof(KDMP_PARSER_EXCEPTION_RECORD64) ==
               "KDMP_PARSER_EXCEPTION_RECORD64's size looks wrong.");
 
 struct KDMP_PARSER_HEADER64 : public DisplayUtils {
-  static const uint32_t ExpectedSignature = 'EGAP';
-  static const uint32_t ExpectedValidDump = '46UD';
+  static const uint32_t ExpectedSignature = 0x45474150; // 'EGAP'
+  static const uint32_t ExpectedValidDump = 0x34365544; // '46UD'
 
   uint32_t Signature;
   uint32_t ValidDump;

--- a/src/lib/kdmp-parser.cc
+++ b/src/lib/kdmp-parser.cc
@@ -86,9 +86,7 @@ const KDMP_PARSER_CONTEXT *KernelDumpParser::GetContext() {
   return &DmpHdr_->ContextRecord;
 }
 
-DumpType_t KernelDumpParser::GetDumpType() {
-    return DmpHdr_->DumpType;
-}
+DumpType_t KernelDumpParser::GetDumpType() { return DmpHdr_->DumpType; }
 
 bool KernelDumpParser::MapFile() { return FileMap_.MapFile(PathFile_); }
 
@@ -153,7 +151,7 @@ bool KernelDumpParser::BuildPhysmemFullDump() {
     //
 
     const KDMP_PARSER_PHYSMEM_RUN *Run =
-        &DmpHdr_->PhysicalMemoryBlockBuffer.Run[RunIdx];
+        DmpHdr_->PhysicalMemoryBlockBuffer.Run + RunIdx;
 
     const uint64_t BasePage = Run->BasePage;
     const uint64_t PageCount = Run->PageCount;
@@ -162,7 +160,7 @@ bool KernelDumpParser::BuildPhysmemFullDump() {
     // Walk the pages from the run.
     //
 
-    for (uint32_t PageIdx = 0; PageIdx < PageCount; PageIdx++) {
+    for (uint64_t PageIdx = 0; PageIdx < PageCount; PageIdx++) {
 
       //
       // Compute the current PFN as well as the actual physical address of the
@@ -200,7 +198,7 @@ bool KernelDumpParser::BuildPhysmemFullDump() {
       // That is the reason why the computation below is RunBase + (PageIdx *
       // 0x1000) instead of RunBase + (Pfn * 0x1000).
 
-      const uint8_t *PageBase = RunBase + (uint64_t(PageIdx) * 0x1000);
+      const uint8_t *PageBase = RunBase + (PageIdx * 0x1000);
 
       //
       // Map the Pfn to a page.

--- a/src/lib/kdmp-parser.cc
+++ b/src/lib/kdmp-parser.cc
@@ -86,6 +86,10 @@ const KDMP_PARSER_CONTEXT *KernelDumpParser::GetContext() {
   return &DmpHdr_->ContextRecord;
 }
 
+DumpType_t KernelDumpParser::GetDumpType() {
+    return DmpHdr_->DumpType;
+}
+
 bool KernelDumpParser::MapFile() { return FileMap_.MapFile(PathFile_); }
 
 bool KernelDumpParser::BuildPhysmemBMPDump() {

--- a/src/lib/kdmp-parser.cc
+++ b/src/lib/kdmp-parser.cc
@@ -1,9 +1,7 @@
 // Axel '0vercl0k' Souchet - February 15 2019
 #include "kdmp-parser.h"
 
-KernelDumpParser::KernelDumpParser()
-    : DmpHdr_(nullptr),
-      PathFile_(nullptr) {}
+KernelDumpParser::KernelDumpParser() : DmpHdr_(nullptr), PathFile_(nullptr) {}
 
 KernelDumpParser::~KernelDumpParser() {
 
@@ -88,9 +86,7 @@ const KDMP_PARSER_CONTEXT *KernelDumpParser::GetContext() {
   return &DmpHdr_->ContextRecord;
 }
 
-bool KernelDumpParser::MapFile() {
-  return FileMap_.MapFile(PathFile_);
-}
+bool KernelDumpParser::MapFile() { return FileMap_.MapFile(PathFile_); }
 
 bool KernelDumpParser::BuildPhysmemBMPDump() {
   const uint8_t *Page = (uint8_t *)DmpHdr_ + DmpHdr_->BmpHeader.FirstPage;
@@ -223,58 +219,75 @@ const Physmem_t &KernelDumpParser::GetPhysmem() { return Physmem_; }
 
 void KernelDumpParser::ShowContextRecord(const uint32_t Prefix = 0) const {
   const KDMP_PARSER_CONTEXT &Context = DmpHdr_->ContextRecord;
-  printf("%*srax=%016llx rbx=%016llx rcx=%016llx\n", Prefix, "", Context.Rax,
-         Context.Rbx, Context.Rcx);
-  printf("%*srdx=%016llx rsi=%016llx rdi=%016llx\n", Prefix, "", Context.Rdx,
-         Context.Rsi, Context.Rdi);
-  printf("%*srip=%016llx rsp=%016llx rbp=%016llx\n", Prefix, "", Context.Rip,
-         Context.Rsp, Context.Rbp);
-  printf("%*s r8=%016llx  r9=%016llx r10=%016llx\n", Prefix, "", Context.R8,
-         Context.R9, Context.R10);
-  printf("%*sr11=%016llx r12=%016llx r13=%016llx\n", Prefix, "", Context.R11,
-         Context.R12, Context.R13);
-  printf("%*sr14=%016llx r15=%016llx\n", Prefix, "", Context.R14, Context.R15);
+  printf("%*srax=%016" PRIx64 " rbx=%016" PRIx64 " rcx=%016" PRIx64 "\n",
+         Prefix, "", Context.Rax, Context.Rbx, Context.Rcx);
+  printf("%*srdx=%016" PRIx64 " rsi=%016" PRIx64 " rdi=%016" PRIx64 "\n",
+         Prefix, "", Context.Rdx, Context.Rsi, Context.Rdi);
+  printf("%*srip=%016" PRIx64 " rsp=%016" PRIx64 " rbp=%016" PRIx64 "\n",
+         Prefix, "", Context.Rip, Context.Rsp, Context.Rbp);
+  printf("%*s r8=%016" PRIx64 "  r9=%016" PRIx64 " r10=%016" PRIx64 "\n",
+         Prefix, "", Context.R8, Context.R9, Context.R10);
+  printf("%*sr11=%016" PRIx64 " r12=%016" PRIx64 " r13=%016" PRIx64 "\n",
+         Prefix, "", Context.R11, Context.R12, Context.R13);
+  printf("%*sr14=%016" PRIx64 " r15=%016" PRIx64 "\n", Prefix, "", Context.R14,
+         Context.R15);
   printf("%*scs=%04x ss=%04x ds=%04x es=%04x fs=%04x gs=%04x    "
          "             efl=%08x\n",
          Prefix, "", Context.SegCs, Context.SegSs, Context.SegDs, Context.SegEs,
          Context.SegFs, Context.SegGs, Context.EFlags);
   printf("%*sfpcw=%04x    fpsw=%04x    fptw=%04x\n", Prefix, "",
          Context.ControlWord, Context.StatusWord, 1);
-  printf("%*s  st0=%016llx%016llx       st1=%016llx%016llx\n", Prefix, "",
-         Context.FloatRegisters[0].High, Context.FloatRegisters[0].Low,
-         Context.FloatRegisters[1].High, Context.FloatRegisters[1].Low);
-  printf("%*s  st2=%016llx%016llx       st3=%016llx%016llx\n", Prefix, "",
-         Context.FloatRegisters[2].High, Context.FloatRegisters[2].Low,
-         Context.FloatRegisters[3].High, Context.FloatRegisters[3].Low);
-  printf("%*s  st4=%016llx%016llx       st5=%016llx%016llx\n", Prefix, "",
-         Context.FloatRegisters[4].High, Context.FloatRegisters[4].Low,
-         Context.FloatRegisters[5].High, Context.FloatRegisters[5].Low);
-  printf("%*s  st6=%016llx%016llx       st7=%016llx%016llx\n", Prefix, "",
-         Context.FloatRegisters[6].High, Context.FloatRegisters[6].Low,
-         Context.FloatRegisters[7].High, Context.FloatRegisters[7].Low);
-  printf("%*s xmm0=%016llx%016llx      xmm1=%016llx%016llx\n", Prefix, "",
-         Context.Xmm0.High, Context.Xmm0.Low, Context.Xmm1.High,
+  printf("%*s  st0=%016" PRIx64 "%016" PRIx64 "       st1=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.FloatRegisters[0].High,
+         Context.FloatRegisters[0].Low, Context.FloatRegisters[1].High,
+         Context.FloatRegisters[1].Low);
+  printf("%*s  st2=%016" PRIx64 "%016" PRIx64 "       st3=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.FloatRegisters[2].High,
+         Context.FloatRegisters[2].Low, Context.FloatRegisters[3].High,
+         Context.FloatRegisters[3].Low);
+  printf("%*s  st4=%016" PRIx64 "%016" PRIx64 "       st5=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.FloatRegisters[4].High,
+         Context.FloatRegisters[4].Low, Context.FloatRegisters[5].High,
+         Context.FloatRegisters[5].Low);
+  printf("%*s  st6=%016" PRIx64 "%016" PRIx64 "       st7=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.FloatRegisters[6].High,
+         Context.FloatRegisters[6].Low, Context.FloatRegisters[7].High,
+         Context.FloatRegisters[7].Low);
+  printf("%*s xmm0=%016" PRIx64 "%016" PRIx64 "      xmm1=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.Xmm0.High, Context.Xmm0.Low, Context.Xmm1.High,
          Context.Xmm1.Low);
-  printf("%*s xmm2=%016llx%016llx      xmm3=%016llx%016llx\n", Prefix, "",
-         Context.Xmm2.High, Context.Xmm2.Low, Context.Xmm3.High,
+  printf("%*s xmm2=%016" PRIx64 "%016" PRIx64 "      xmm3=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.Xmm2.High, Context.Xmm2.Low, Context.Xmm3.High,
          Context.Xmm3.Low);
-  printf("%*s xmm4=%016llx%016llx      xmm5=%016llx%016llx\n", Prefix, "",
-         Context.Xmm4.High, Context.Xmm4.Low, Context.Xmm5.High,
+  printf("%*s xmm4=%016" PRIx64 "%016" PRIx64 "      xmm5=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.Xmm4.High, Context.Xmm4.Low, Context.Xmm5.High,
          Context.Xmm5.Low);
-  printf("%*s xmm6=%016llx%016llx      xmm7=%016llx%016llx\n", Prefix, "",
-         Context.Xmm6.High, Context.Xmm6.Low, Context.Xmm7.High,
+  printf("%*s xmm6=%016" PRIx64 "%016" PRIx64 "      xmm7=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.Xmm6.High, Context.Xmm6.Low, Context.Xmm7.High,
          Context.Xmm7.Low);
-  printf("%*s xmm8=%016llx%016llx      xmm9=%016llx%016llx\n", Prefix, "",
-         Context.Xmm8.High, Context.Xmm8.Low, Context.Xmm9.High,
+  printf("%*s xmm8=%016" PRIx64 "%016" PRIx64 "      xmm9=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.Xmm8.High, Context.Xmm8.Low, Context.Xmm9.High,
          Context.Xmm9.Low);
-  printf("%*sxmm10=%016llx%016llx     xmm11=%016llx%016llx\n", Prefix, "",
-         Context.Xmm10.High, Context.Xmm10.Low, Context.Xmm11.High,
+  printf("%*sxmm10=%016" PRIx64 "%016" PRIx64 "     xmm11=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.Xmm10.High, Context.Xmm10.Low, Context.Xmm11.High,
          Context.Xmm11.Low);
-  printf("%*sxmm12=%016llx%016llx     xmm13=%016llx%016llx\n", Prefix, "",
-         Context.Xmm12.High, Context.Xmm12.Low, Context.Xmm13.High,
+  printf("%*sxmm12=%016" PRIx64 "%016" PRIx64 "     xmm13=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.Xmm12.High, Context.Xmm12.Low, Context.Xmm13.High,
          Context.Xmm13.Low);
-  printf("%*sxmm14=%016llx%016llx     xmm15=%016llx%016llx\n", Prefix, "",
-         Context.Xmm14.High, Context.Xmm14.Low, Context.Xmm15.High,
+  printf("%*sxmm14=%016" PRIx64 "%016" PRIx64 "     xmm15=%016" PRIx64
+         "%016" PRIx64 "\n",
+         Prefix, "", Context.Xmm14.High, Context.Xmm14.Low, Context.Xmm15.High,
          Context.Xmm15.Low);
 }
 

--- a/src/lib/kdmp-parser.h
+++ b/src/lib/kdmp-parser.h
@@ -26,6 +26,12 @@ public:
   const KDMP_PARSER_CONTEXT *GetContext();
 
   //
+  // Get the type of dump.
+  //
+
+  DumpType_t GetDumpType();
+
+  //
   // Get the physmem.
   //
 

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -2,8 +2,8 @@
 #include "kdmp-parser.h"
 
 #include <algorithm>
-#include <vector>
 #include <cstring>
+#include <vector>
 
 //
 // Delimiter.
@@ -112,7 +112,7 @@ void Hexdump(const uint64_t Address, const void *Buffer, size_t Len) {
   const uint8_t *ptr = (uint8_t *)Buffer;
 
   for (size_t i = 0; i < Len; i += 16) {
-    printf("%08llx: ", Address + i);
+    printf("%08" PRIx64 ": ", Address + i);
     for (int j = 0; j < 16; j++) {
       if (i + j < Len) {
         printf("%02x ", ptr[i + j]);
@@ -325,7 +325,7 @@ int main(int argc, const char *argv[]) {
 
       const uint8_t *Page = Dmp.GetPhysicalPage(Opts.PhysicalAddress);
       if (Page == nullptr) {
-        printf("0x%llx is not a valid physical address.\n",
+        printf("0x%" PRIx64 " is not a valid physical address.\n",
                Opts.PhysicalAddress);
       } else {
         Hexdump(Opts.PhysicalAddress, Page, 0x1000);

--- a/src/testapp/testapp.cc
+++ b/src/testapp/testapp.cc
@@ -26,87 +26,104 @@ int main(int argc, const char *argv[]) {
 
   const KDMP_PARSER_CONTEXT *C = Dmp.GetContext();
   if (C->Rax != 0x0000000000000003ULL) {
-    printf("Rax(0x%016llx) does not match with 0x0000000000000003.", C->Rax);
+    printf("Rax(0x%016" PRIx64 ") does not match with 0x0000000000000003.",
+           C->Rax);
     return EXIT_FAILURE;
   }
 
   if (C->Rbx != 0xfffff8050f4e9f70ULL) {
-    printf("Rbx(0x%016llx) does not match with 0xfffff8050f4e9f70.", C->Rbx);
+    printf("Rbx(0x%016" PRIx64 ") does not match with 0xfffff8050f4e9f70.",
+           C->Rbx);
     return EXIT_FAILURE;
   }
 
   if (C->Rcx != 0x0000000000000001ULL) {
-    printf("Rcx(0x%016llx) does not match with 0x0000000000000001.", C->Rcx);
+    printf("Rcx(0x%016" PRIx64 ") does not match with 0x0000000000000001.",
+           C->Rcx);
     return EXIT_FAILURE;
   }
 
   if (C->Rdx != 0xfffff805135684d0ULL) {
-    printf("Rdx(0x%016llx) does not match with 0xfffff805135684d0.", C->Rdx);
+    printf("Rdx(0x%016" PRIx64 ") does not match with 0xfffff805135684d0.",
+           C->Rdx);
     return EXIT_FAILURE;
   }
 
   if (C->Rsi != 0x0000000000000100ULL) {
-    printf("Rsi(0x%016llx) does not match with 0x0000000000000100.", C->Rsi);
+    printf("Rsi(0x%016" PRIx64 ") does not match with 0x0000000000000100.",
+           C->Rsi);
     return EXIT_FAILURE;
   }
 
   if (C->Rdi != 0xfffff8050f4e9f80ULL) {
-    printf("Rdi(0x%016llx) does not match with 0xfffff8050f4e9f80.", C->Rdi);
+    printf("Rdi(0x%016" PRIx64 ") does not match with 0xfffff8050f4e9f80.",
+           C->Rdi);
     return EXIT_FAILURE;
   }
 
   if (C->Rip != 0xfffff805108776a0ULL) {
-    printf("Rip(0x%016llx) does not match with 0xfffff805108776a0.", C->Rip);
+    printf("Rip(0x%016" PRIx64 ") does not match with 0xfffff805108776a0.",
+           C->Rip);
     return EXIT_FAILURE;
   }
 
   if (C->Rsp != 0xfffff805135684f8ULL) {
-    printf("Rsp(0x%016llx) does not match with 0xfffff805135684f8.", C->Rsp);
+    printf("Rsp(0x%016" PRIx64 ") does not match with 0xfffff805135684f8.",
+           C->Rsp);
     return EXIT_FAILURE;
   }
 
   if (C->Rbp != 0xfffff80513568600ULL) {
-    printf("Rbp(0x%016llx) does not match with 0xfffff80513568600.", C->Rbp);
+    printf("Rbp(0x%016" PRIx64 ") does not match with 0xfffff80513568600.",
+           C->Rbp);
     return EXIT_FAILURE;
   }
 
   if (C->R8 != 0x0000000000000003ULL) {
-    printf("R8(0x%016llx) does not match with 0x0000000000000003.", C->R8);
+    printf("R8(0x%016" PRIx64 ") does not match with 0x0000000000000003.",
+           C->R8);
     return EXIT_FAILURE;
   }
 
   if (C->R9 != 0xfffff805135684b8ULL) {
-    printf("R9(0x%016llx) does not match with 0xfffff805135684b8.", C->R9);
+    printf("R9(0x%016" PRIx64 ") does not match with 0xfffff805135684b8.",
+           C->R9);
     return EXIT_FAILURE;
   }
 
   if (C->R10 != 0x0000000000000000ULL) {
-    printf("R10(0x%016llx) does not match with 0x0000000000000000.", C->R10);
+    printf("R10(0x%016" PRIx64 ") does not match with 0x0000000000000000.",
+           C->R10);
     return EXIT_FAILURE;
   }
 
   if (C->R11 != 0xffffa8848825e000ULL) {
-    printf("R11(0x%016llx) does not match with 0xffffa8848825e000.", C->R11);
+    printf("R11(0x%016" PRIx64 ") does not match with 0xffffa8848825e000.",
+           C->R11);
     return EXIT_FAILURE;
   }
 
   if (C->R12 != 0xfffff8050f4e9f80ULL) {
-    printf("R12(0x%016llx) does not match with 0xfffff8050f4e9f80.", C->R12);
+    printf("R12(0x%016" PRIx64 ") does not match with 0xfffff8050f4e9f80.",
+           C->R12);
     return EXIT_FAILURE;
   }
 
   if (C->R13 != 0xfffff80510c3c958ULL) {
-    printf("R13(0x%016llx) does not match with 0xfffff80510c3c958.", C->R13);
+    printf("R13(0x%016" PRIx64 ") does not match with 0xfffff80510c3c958.",
+           C->R13);
     return EXIT_FAILURE;
   }
 
   if (C->R14 != 0x0000000000000000ULL) {
-    printf("R14(0x%016llx) does not match with 0x0000000000000000.", C->R14);
+    printf("R14(0x%016" PRIx64 ") does not match with 0x0000000000000000.",
+           C->R14);
     return EXIT_FAILURE;
   }
 
   if (C->R15 != 0x0000000000000052ULL) {
-    printf("R15(0x%016llx) does not match with 0x0000000000000052.", C->R15);
+    printf("R15(0x%016" PRIx64 ") does not match with 0x0000000000000052.",
+           C->R15);
     return EXIT_FAILURE;
   }
 

--- a/src/testapp/testapp.cc
+++ b/src/testapp/testapp.cc
@@ -130,6 +130,23 @@ int main(int argc, const char *argv[]) {
 
   printf("GPRs matches the testdatas.\n");
 
+  const DumpType_t Type = Dmp.GetDumpType();
+  const auto &Physmem = Dmp.GetPhysmem();
+  if (Type == DumpType_t::BMPDump) {
+    if (Physmem.size() != 0x544b) {
+      printf("0x544b pages are expected but found %zd.\n", Physmem.size());
+      return EXIT_FAILURE;
+    }
+  } else if (Type == DumpType_t::FullDump) {
+    if (Physmem.size() != 0x3fbe6) {
+      printf("0x3fbe6 pages are expected but found %zd.\n", Physmem.size());
+      return EXIT_FAILURE;
+    }
+  } else {
+    printf("Unknown dump.\n");
+    return EXIT_FAILURE;
+  }
+
   const uint64_t Address = 0x6d4d22;
   const uint64_t AddressAligned = Address & 0xfffffffffffff000;
   const uint64_t AddressOffset = Address & 0xfff;

--- a/src/testapp/testapp.cc
+++ b/src/testapp/testapp.cc
@@ -137,6 +137,11 @@ int main(int argc, const char *argv[]) {
                                      0x63, 0x88, 0x75, 0x00, 0x00, 0x00,
                                      0x00, 0x0a, 0x63, 0x98};
   const uint8_t *Page = Dmp.GetPhysicalPage(AddressAligned);
+  if (Page == nullptr) {
+    printf("GetPhysicalPage failed for %p\n", Page);
+    return EXIT_FAILURE;
+  }
+
   if (memcmp(Page + AddressOffset, ExpectedContent, sizeof(ExpectedContent)) !=
       0) {
     printf("Physical memory is broken.\n");

--- a/src/testapp/testapp.cc
+++ b/src/testapp/testapp.cc
@@ -1,5 +1,6 @@
 // Axel '0vercl0k' Souchet - February 15 2019
 #include "kdmp-parser.h"
+#include <cstring>
 
 int main(int argc, const char *argv[]) {
   if (argc != 2) {
@@ -129,5 +130,19 @@ int main(int argc, const char *argv[]) {
 
   printf("GPRs matches the testdatas.\n");
 
+  const uint64_t Address = 0x6d4d22;
+  const uint64_t AddressAligned = Address & 0xfffffffffffff000;
+  const uint64_t AddressOffset = Address & 0xfff;
+  const uint8_t ExpectedContent[] = {0x6d, 0x00, 0x00, 0x00, 0x00, 0x0a,
+                                     0x63, 0x88, 0x75, 0x00, 0x00, 0x00,
+                                     0x00, 0x0a, 0x63, 0x98};
+  const uint8_t *Page = Dmp.GetPhysicalPage(AddressAligned);
+  if (memcmp(Page + AddressOffset, ExpectedContent, sizeof(ExpectedContent)) !=
+      0) {
+    printf("Physical memory is broken.\n");
+    return EXIT_FAILURE;
+  }
+
+  printf("Physical memory page matches the testdatas.\n");
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- Clean the build system - actually create 32b binaries for Windows / Linux
- Use g++/clang as part of a matrix in travis-ci
- Add a few more tests
- The code should be now free of warnings on both platforms