### PR TITLE
Make dumps of type `CompleteMemoryDump` trust `TotalNumberOfPages` header field instead of just `MetadataSize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The library supports loading 64-bit dumps and provides read access to things lik
 Compiled binaries are available in the [releases](https://github.com/0vercl0k/kdmp-parser/releases) section.
 
 Special thanks to:
+- [hugsy](https://github.com/hugsy) for numerous contributions: Python bindings, CI improvements, new dump types, etc.,
 - [yrp604](https://github.com/yrp604) for being knowledgeable about the format,
 - the [rekall](https://github.com/google/rekall) project and their [Python implementation](https://github.com/google/rekall/blob/master/rekall-core/rekall/plugins/overlays/windows/crashdump.py) (most of the structures in [kdmp-parser-structs.h](https://github.com/0vercl0k/kdmp-parser/blob/master/src/kdmp-parser/kdmp-parser-structs.h) have been adapted from it).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The library supports loading 64-bit dumps and provides read access to things lik
 Compiled binaries are available in the [releases](https://github.com/0vercl0k/kdmp-parser/releases) section.
 
 Special thanks to:
-- [hugsy](https://github.com/hugsy) for numerous contributions: Python bindings, CI improvements, new dump types, etc.,
+- [hugsy](https://github.com/hugsy) for numerous contributions: the new Python bindings, CI improvements, new dump types, etc.,
+- [masthoon](https://github.com/masthoon) for the initial version of the Python bindings,
 - [yrp604](https://github.com/yrp604) for being knowledgeable about the format,
 - the [rekall](https://github.com/google/rekall) project and their [Python implementation](https://github.com/google/rekall/blob/master/rekall-core/rekall/plugins/overlays/windows/crashdump.py) (most of the structures in [kdmp-parser-structs.h](https://github.com/0vercl0k/kdmp-parser/blob/master/src/kdmp-parser/kdmp-parser-structs.h) have been adapted from it).
 

--- a/src/lib/kdmp-parser.h
+++ b/src/lib/kdmp-parser.h
@@ -631,7 +631,6 @@ private:
 
     // Sanity check
     if (MetadataSize % sizeof(PfnRange)) {
-      // printf("MetadataSize field is invalid, value=%llx\r\n", MetadataSize);
       return false;
     }
 

--- a/src/lib/kdmp-parser.h
+++ b/src/lib/kdmp-parser.h
@@ -585,8 +585,8 @@ private:
     uint8_t *Page = nullptr;
     uint64_t MetadataSize = 0;
     uint8_t *Bitmap = nullptr;
-    uint64_t TotalNumberOfPages{};
-    uint64_t CurrentPageCount{};
+    uint64_t TotalNumberOfPages = 0;
+    uint64_t CurrentPageCount = 0;
 
     switch (Type) {
     case DumpType_t::KernelMemoryDump:
@@ -639,12 +639,14 @@ private:
 
       if (Type == DumpType_t::CompleteMemoryDump) {
         // `CompleteMemoryDump` type seems to be bound by the
-        // `TotalNumberOfPages` field, *not* by `MetadataSize`
-        if (CurrentPageCount == TotalNumberOfPages)
+        // `TotalNumberOfPages` field, *not* by `MetadataSize`.
+        if (CurrentPageCount == TotalNumberOfPages) {
           break;
+        }
 
-        if (CurrentPageCount > TotalNumberOfPages)
+        if (CurrentPageCount > TotalNumberOfPages) {
           return false;
+        }
       }
 
       const PfnRange &Entry = (PfnRange &)Bitmap[Offset];

--- a/src/lib/kdmp-parser.h
+++ b/src/lib/kdmp-parser.h
@@ -640,7 +640,7 @@ private:
       if (Type == DumpType_t::CompleteMemoryDump) {
         // `CompleteMemoryDump` type seems to be bound by the
         // `TotalNumberOfPages` field, *not* by `MetadataSize`
-        if (CurrentPageCount == TotalNumberOfPages) // [[unlikely]]
+        if (CurrentPageCount == TotalNumberOfPages)
           break;
 
         if (CurrentPageCount > TotalNumberOfPages)

--- a/src/lib/kdmp-parser.h
+++ b/src/lib/kdmp-parser.h
@@ -585,6 +585,8 @@ private:
     uint8_t *Page = nullptr;
     uint64_t MetadataSize = 0;
     uint8_t *Bitmap = nullptr;
+    uint64_t TotalNumberOfPages{};
+    uint64_t CurrentPageCount{};
 
     switch (Type) {
     case DumpType_t::KernelMemoryDump:
@@ -597,10 +599,11 @@ private:
     }
 
     case DumpType_t::CompleteMemoryDump: {
-      FirstPageOffset = DmpHdr_->u3.RdmpHeader.Hdr.FirstPageOffset;
+      FirstPageOffset = DmpHdr_->u3.FullRdmpHeader.Hdr.FirstPageOffset;
       Page = (uint8_t *)DmpHdr_ + FirstPageOffset;
       MetadataSize = DmpHdr_->u3.FullRdmpHeader.Hdr.MetadataSize;
       Bitmap = DmpHdr_->u3.FullRdmpHeader.Bitmap.data();
+      TotalNumberOfPages = DmpHdr_->u3.FullRdmpHeader.TotalNumberOfPages;
       break;
     }
 
@@ -626,12 +629,31 @@ private:
       uint64_t NumberOfPages;
     };
 
+    // Sanity check
+    if (MetadataSize % sizeof(PfnRange)) {
+      // printf("MetadataSize field is invalid, value=%llx\r\n", MetadataSize);
+      return false;
+    }
+
     for (uint64_t Offset = 0; Offset < MetadataSize;
          Offset += sizeof(PfnRange)) {
+
+      if (Type == DumpType_t::CompleteMemoryDump) {
+        // `CompleteMemoryDump` type seems to be bound by the
+        // `TotalNumberOfPages` field, *not* by `MetadataSize`
+        if (CurrentPageCount == TotalNumberOfPages) // [[unlikely]]
+          break;
+
+        if (CurrentPageCount > TotalNumberOfPages)
+          return false;
+      }
+
       const PfnRange &Entry = (PfnRange &)Bitmap[Offset];
       if (!FileMap_.InBounds(&Entry, sizeof(Entry))) {
         return false;
       }
+
+      CurrentPageCount += Entry.NumberOfPages;
 
       const uint64_t Pfn = Entry.PageFileNumber;
       if (!Pfn) {


### PR DESCRIPTION
This fixes #27 

When parsing a `DumpType_t::CompleteMemoryDump` type of dump, it seems that the field `MetadataSize` field from the RdmpHeader can exceed the actual number of `PfnRange` class entries declared. Since we properly check bounds, it will result in a failure. 

This PR adds a extra check only for `CompleteMemoryDump` to enforce a strict check of the current number of pages declared **and** stop parsing when the expected number of pages (declared in `FullRdmpHeader.TotalNumberOfPages`) is reached.