### PR TITLE
Adding support for "Live Kernel Memory" dump type (0x6)

### DIFF
--- a/.github/workflows/kdmp-parser.yml
+++ b/.github/workflows/kdmp-parser.yml
@@ -40,7 +40,7 @@ jobs:
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo}
           - {os: ubuntu-latest, generator: gcc, arch: x64, config: RelWithDebInfo}
           - {os: ubuntu-latest, generator: clang, arch: x64, config: RelWithDebInfo}
-          - {os: macos-latest, generator: clang, arch: x64, config: Release}
+          - {os: macos-latest-large, generator: clang, arch: x64, config: Release}
     runs-on: ${{ matrix.variant.os }}
     name: parser / ${{ matrix.variant.os }} / ${{ matrix.variant.generator }} / ${{ matrix.variant.arch }}
     env:

--- a/.github/workflows/kdmp-parser.yml
+++ b/.github/workflows/kdmp-parser.yml
@@ -115,7 +115,7 @@ jobs:
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo, py-arch: x64} # Unsupported (see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)
           - {os: ubuntu-latest, generator: gcc, arch: x64, config: RelWithDebInfo, py-arch: x64}
           - {os: ubuntu-latest, generator: clang, arch: x64, config: RelWithDebInfo, py-arch: x64}
-          - {os: macos-latest-large, generator: clang, arch: x64, config: Release, py-arch: x64}
+          - {os: macos-13, generator: clang, arch: x64, config: Release, py-arch: x64}
     runs-on: ${{ matrix.variant.os }}
     name: bindings / ${{ matrix.variant.os }} / ${{ matrix.variant.generator }} / ${{ matrix.python-version }} / ${{ matrix.variant.arch }}
     env:

--- a/.github/workflows/kdmp-parser.yml
+++ b/.github/workflows/kdmp-parser.yml
@@ -38,8 +38,8 @@ jobs:
           - {os: windows-2019, generator: ninja, arch: x64, config: RelWithDebInfo}
           - {os: windows-2019, generator: msvc, arch: win32, config: RelWithDebInfo}
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo}
-          - {os: ubuntu-latest, generator: gcc, arch: x64, config: RelWithDebInfo}
-          - {os: ubuntu-latest, generator: clang, arch: x64, config: RelWithDebInfo}
+          - {os: ubuntu-2204, generator: gcc, arch: x64, config: RelWithDebInfo}
+          - {os: ubuntu-2204, generator: clang, arch: x64, config: RelWithDebInfo}
           # most up to date free intel based osx?
           - {os: macos-13, generator: clang, arch: x64, config: Release}
     runs-on: ${{ matrix.variant.os }}
@@ -114,8 +114,8 @@ jobs:
           - {os: windows-2019, generator: msvc, arch: x64, config: RelWithDebInfo, py-arch: x64}
           - {os: windows-2019, generator: msvc, arch: win32, config: RelWithDebInfo, py-arch: x86}
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo, py-arch: x64} # Unsupported (see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)
-          - {os: ubuntu-latest, generator: gcc, arch: x64, config: RelWithDebInfo, py-arch: x64}
-          - {os: ubuntu-latest, generator: clang, arch: x64, config: RelWithDebInfo, py-arch: x64}
+          - {os: ubuntu-2204, generator: gcc, arch: x64, config: RelWithDebInfo}
+          - {os: ubuntu-2204, generator: clang, arch: x64, config: RelWithDebInfo}
           # most up to date free intel based osx?
           - {os: macos-13, generator: clang, arch: x64, config: Release, py-arch: x64}
     runs-on: ${{ matrix.variant.os }}

--- a/.github/workflows/kdmp-parser.yml
+++ b/.github/workflows/kdmp-parser.yml
@@ -115,7 +115,7 @@ jobs:
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo, py-arch: x64} # Unsupported (see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)
           - {os: ubuntu-latest, generator: gcc, arch: x64, config: RelWithDebInfo, py-arch: x64}
           - {os: ubuntu-latest, generator: clang, arch: x64, config: RelWithDebInfo, py-arch: x64}
-          - {os: macos-latest, generator: clang, arch: x64, config: Release, py-arch: x64}
+          - {os: macos-latest-large, generator: clang, arch: x64, config: Release, py-arch: x64}
     runs-on: ${{ matrix.variant.os }}
     name: bindings / ${{ matrix.variant.os }} / ${{ matrix.variant.generator }} / ${{ matrix.python-version }} / ${{ matrix.variant.arch }}
     env:
@@ -148,7 +148,7 @@ jobs:
         sudo apt-get -y update
 
     - name: Environment Setup (OSX)
-      if: matrix.variant.os == 'macos-latest'
+      if: matrix.variant.os == 'macos-latest-large'
       run: |
         echo
 

--- a/.github/workflows/kdmp-parser.yml
+++ b/.github/workflows/kdmp-parser.yml
@@ -38,8 +38,8 @@ jobs:
           - {os: windows-2019, generator: ninja, arch: x64, config: RelWithDebInfo}
           - {os: windows-2019, generator: msvc, arch: win32, config: RelWithDebInfo}
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo}
-          - {os: ubuntu-2204, generator: gcc, arch: x64, config: RelWithDebInfo}
-          - {os: ubuntu-2204, generator: clang, arch: x64, config: RelWithDebInfo}
+          - {os: ubuntu-22.04, generator: gcc, arch: x64, config: RelWithDebInfo}
+          - {os: ubuntu-22.04, generator: clang, arch: x64, config: RelWithDebInfo}
           # most up to date free intel based osx?
           - {os: macos-13, generator: clang, arch: x64, config: Release}
     runs-on: ${{ matrix.variant.os }}
@@ -114,8 +114,8 @@ jobs:
           - {os: windows-2019, generator: msvc, arch: x64, config: RelWithDebInfo, py-arch: x64}
           - {os: windows-2019, generator: msvc, arch: win32, config: RelWithDebInfo, py-arch: x86}
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo, py-arch: x64} # Unsupported (see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)
-          - {os: ubuntu-2204, generator: gcc, arch: x64, config: RelWithDebInfo}
-          - {os: ubuntu-2204, generator: clang, arch: x64, config: RelWithDebInfo}
+          - {os: ubuntu-22.04, generator: gcc, arch: x64, config: RelWithDebInfo}
+          - {os: ubuntu-22.04, generator: clang, arch: x64, config: RelWithDebInfo}
           # most up to date free intel based osx?
           - {os: macos-13, generator: clang, arch: x64, config: Release, py-arch: x64}
     runs-on: ${{ matrix.variant.os }}

--- a/.github/workflows/kdmp-parser.yml
+++ b/.github/workflows/kdmp-parser.yml
@@ -40,7 +40,7 @@ jobs:
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo}
           - {os: ubuntu-latest, generator: gcc, arch: x64, config: RelWithDebInfo}
           - {os: ubuntu-latest, generator: clang, arch: x64, config: RelWithDebInfo}
-          - {os: macos-latest-large, generator: clang, arch: x64, config: Release}
+          - {os: macos-13, generator: clang, arch: x64, config: Release}
     runs-on: ${{ matrix.variant.os }}
     name: parser / ${{ matrix.variant.os }} / ${{ matrix.variant.generator }} / ${{ matrix.variant.arch }}
     env:

--- a/.github/workflows/kdmp-parser.yml
+++ b/.github/workflows/kdmp-parser.yml
@@ -66,19 +66,19 @@ jobs:
         echo "CMAKE_ARCH='-A ${{ matrix.variant.arch }}'" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Environment Setup (Linux)
-      if: matrix.variant.os == 'ubuntu-latest'
+      if: matrix.variant.os == 'ubuntu-22.04'
       run: |
         sudo apt update
 
     - name: Build (Linux/GCC)
-      if: matrix.variant.os == 'ubuntu-latest' && matrix.variant.generator == 'gcc'
+      if: matrix.variant.os == 'ubuntu-22.04' && matrix.variant.generator == 'gcc'
       run: |
         sudo apt install -y g++
         echo CC=gcc >> $GITHUB_ENV
         echo CXX=g++ >> $GITHUB_ENV
 
     - name: Environment Setup (Linux/CLang)
-      if: matrix.variant.os == 'ubuntu-latest' && matrix.variant.generator == 'clang'
+      if: matrix.variant.os == 'ubuntu-22.04' && matrix.variant.generator == 'clang'
       run: |
         sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
         echo CC=clang >> $GITHUB_ENV
@@ -145,24 +145,24 @@ jobs:
         Invoke-VisualStudio2022${{ matrix.variant.arch }}
 
     - name: Environment Setup (Linux)
-      if: matrix.variant.os == 'ubuntu-latest'
+      if: matrix.variant.os == 'ubuntu-22.04'
       run: |
         sudo apt-get -y update
 
     - name: Environment Setup (OSX)
-      if: matrix.variant.os == 'macos-latest-large'
+      if: matrix.variant.os == 'macos-13'
       run: |
         echo
 
     - name: Environment Setup (Linux/GCC)
-      if: matrix.variant.os == 'ubuntu-latest' && matrix.variant.generator == 'gcc'
+      if: matrix.variant.os == 'ubuntu-22.04' && matrix.variant.generator == 'gcc'
       run: |
         sudo apt install -y g++
         echo CC=gcc >> $GITHUB_ENV
         echo CXX=g++ >> $GITHUB_ENV
 
     - name: Environment Setup (Linux/CLang)
-      if: matrix.variant.os == 'ubuntu-latest' && matrix.variant.generator == 'clang'
+      if: matrix.variant.os == 'ubuntu-22.04' && matrix.variant.generator == 'clang'
       run: |
         sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
         echo CC=clang >> $GITHUB_ENV

--- a/.github/workflows/kdmp-parser.yml
+++ b/.github/workflows/kdmp-parser.yml
@@ -34,12 +34,13 @@ jobs:
       fail-fast: false
       matrix:
         variant:
-          - {os: windows-latest, generator: msvc, arch: x64, config: RelWithDebInfo}
-          - {os: windows-latest, generator: ninja, arch: x64, config: RelWithDebInfo}
-          - {os: windows-latest, generator: msvc, arch: win32, config: RelWithDebInfo}
+          - {os: windows-2019, generator: msvc, arch: x64, config: RelWithDebInfo}
+          - {os: windows-2019, generator: ninja, arch: x64, config: RelWithDebInfo}
+          - {os: windows-2019, generator: msvc, arch: win32, config: RelWithDebInfo}
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo}
           - {os: ubuntu-latest, generator: gcc, arch: x64, config: RelWithDebInfo}
           - {os: ubuntu-latest, generator: clang, arch: x64, config: RelWithDebInfo}
+          # most up to date free intel based osx?
           - {os: macos-13, generator: clang, arch: x64, config: Release}
     runs-on: ${{ matrix.variant.os }}
     name: parser / ${{ matrix.variant.os }} / ${{ matrix.variant.generator }} / ${{ matrix.variant.arch }}
@@ -58,7 +59,7 @@ jobs:
         path: .
 
     - name: Environment Setup (Windows)
-      if: matrix.variant.os == 'windows-latest'
+      if: matrix.variant.os == 'windows-2019'
       run: |
         Import-Module .\.github\Invoke-VisualStudio.ps1
         Invoke-VisualStudio2022${{ matrix.variant.arch }}
@@ -110,11 +111,12 @@ jobs:
         # nanobind does not support Python < 3.8.
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         variant:
-          - {os: windows-latest, generator: msvc, arch: x64, config: RelWithDebInfo, py-arch: x64}
-          - {os: windows-latest, generator: msvc, arch: win32, config: RelWithDebInfo, py-arch: x86}
+          - {os: windows-2019, generator: msvc, arch: x64, config: RelWithDebInfo, py-arch: x64}
+          - {os: windows-2019, generator: msvc, arch: win32, config: RelWithDebInfo, py-arch: x86}
           # - {os: windows-latest, generator: msvc, arch: arm64, config: RelWithDebInfo, py-arch: x64} # Unsupported (see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)
           - {os: ubuntu-latest, generator: gcc, arch: x64, config: RelWithDebInfo, py-arch: x64}
           - {os: ubuntu-latest, generator: clang, arch: x64, config: RelWithDebInfo, py-arch: x64}
+          # most up to date free intel based osx?
           - {os: macos-13, generator: clang, arch: x64, config: Release, py-arch: x64}
     runs-on: ${{ matrix.variant.os }}
     name: bindings / ${{ matrix.variant.os }} / ${{ matrix.variant.generator }} / ${{ matrix.python-version }} / ${{ matrix.variant.arch }}
@@ -137,7 +139,7 @@ jobs:
         architecture: ${{ matrix.variant.py-arch }}
 
     - name: Environment Setup (Windows)
-      if: matrix.variant.os == 'windows-latest'
+      if: matrix.variant.os == 'windows-2019'
       run: |
         Import-Module .\.github\Invoke-VisualStudio.ps1
         Invoke-VisualStudio2022${{ matrix.variant.arch }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(
     kdmp-parser
     DESCRIPTION "A Cross-Platform C++ parser library for Windows kernel minidumps."
     HOMEPAGE_URL https://github.com/0vercl0k/kdmp-parser
-    VERSION 0.7.2
+    VERSION 0.7.3
 )
 
 set(PROJECT_AUTHOR 0vercl0k)

--- a/src/lib/kdmp-parser-structs.h
+++ b/src/lib/kdmp-parser-structs.h
@@ -31,8 +31,10 @@ enum class DumpType_t : uint32_t {
   BMPDump = 0x5,
 
   // New stuff
-  MiniDump = 0x4,                // Produced by `.dump /m`
-  KernelMemoryDump = 0x8,        // Produced by `.dump /k`
+  MiniDump = 0x4,             // Produced by `.dump /m`
+  LiveKernelBitmapDump = 0x6, // (22h2+) Produced by TaskMgr > System > Create
+                              // Live Kernel Memory Dump
+  KernelMemoryDump = 0x8,     // Produced by `.dump /k`
   KernelAndUserMemoryDump = 0x9, // Produced by `.dump /ka`
   CompleteMemoryDump = 0xa,      // Produced by `.dump /f`
 };
@@ -88,6 +90,8 @@ constexpr std::string_view DumpTypeToString(const DumpType_t Type) {
   // New stuff
   case DumpType_t::MiniDump:
     return "MiniDump";
+  case DumpType_t::LiveKernelBitmapDump:
+    return "LiveKernelBitmapDump";
   case DumpType_t::KernelMemoryDump:
     return "KernelMemoryDump";
   case DumpType_t::KernelAndUserMemoryDump:
@@ -750,6 +754,7 @@ struct HEADER64 {
       break;
     }
 
+    case DumpType_t::LiveKernelBitmapDump:
     case DumpType_t::BMPDump: {
       if (!u3.BmpHeader.LooksGood()) {
         printf("The BmpHeader looks wrong.\n");

--- a/src/lib/kdmp-parser.h
+++ b/src/lib/kdmp-parser.h
@@ -96,6 +96,7 @@ public:
       }
       break;
     }
+    case DumpType_t::LiveKernelBitmapDump:
     case DumpType_t::BMPDump: {
       if (!BuildPhysmemBMPDump()) {
         printf("BuildPhysmemBMPDump failed.\n");

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -13,7 +13,7 @@ project(
     kdmp-parser-python
     DESCRIPTION "A Cross-Platform C++ parser library for Windows kernel minidumps."
     HOMEPAGE_URL https://github.com/0vercl0k/kdmp-parser
-    VERSION 0.7.2
+    VERSION 0.7.3
 )
 set(PROJECT_AUTHOR 0vercl0k)
 set(PROJECT_LICENSE MIT)

--- a/src/python/kdmp_parser/__init__.py
+++ b/src/python/kdmp_parser/__init__.py
@@ -24,14 +24,14 @@ from .page import (
 
 
 class DumpType(enum.IntEnum):
-    FullDump = int(_DumpType_t.FullDump)
-    KernelDump = int(_DumpType_t.KernelDump)
-    BMPDump = int(_DumpType_t.BMPDump)
-    LiveKernelBitmapDump = int(_DumpType_t.LiveKernelBitmapDump)
-    MiniDump = int(_DumpType_t.MiniDump)
-    KernelMemoryDump = int(_DumpType_t.KernelMemoryDump)
-    KernelAndUserMemoryDump = int(_DumpType_t.KernelAndUserMemoryDump)
-    CompleteMemoryDump = int(_DumpType_t.CompleteMemoryDump)
+    FullDump = _DumpType_t.FullDump.value
+    KernelDump = _DumpType_t.KernelDump.value
+    BMPDump = _DumpType_t.BMPDump.value
+    LiveKernelBitmapDump = _DumpType_t.LiveKernelBitmapDump.value
+    MiniDump = _DumpType_t.MiniDump.value
+    KernelMemoryDump = _DumpType_t.KernelMemoryDump.value
+    KernelAndUserMemoryDump = _DumpType_t.KernelAndUserMemoryDump.value
+    CompleteMemoryDump = _DumpType_t.CompleteMemoryDump.value
 
 
 class KernelDumpParser:

--- a/src/python/kdmp_parser/__init__.py
+++ b/src/python/kdmp_parser/__init__.py
@@ -24,14 +24,14 @@ from .page import (
 
 
 class DumpType(enum.IntEnum):
-    FullDump = _DumpType_t.FullDump
-    KernelDump = _DumpType_t.KernelDump
-    BMPDump = _DumpType_t.BMPDump
-    LiveKernelBitmapDump = _DumpType_t.LiveKernelBitmapDump
-    MiniDump = _DumpType_t.MiniDump
-    KernelMemoryDump = _DumpType_t.KernelMemoryDump
-    KernelAndUserMemoryDump = _DumpType_t.KernelAndUserMemoryDump
-    CompleteMemoryDump = _DumpType_t.CompleteMemoryDump
+    FullDump = int(_DumpType_t.FullDump)
+    KernelDump = int(_DumpType_t.KernelDump)
+    BMPDump = int(_DumpType_t.BMPDump)
+    LiveKernelBitmapDump = int(_DumpType_t.LiveKernelBitmapDump)
+    MiniDump = int(_DumpType_t.MiniDump)
+    KernelMemoryDump = int(_DumpType_t.KernelMemoryDump)
+    KernelAndUserMemoryDump = int(_DumpType_t.KernelAndUserMemoryDump)
+    CompleteMemoryDump = int(_DumpType_t.CompleteMemoryDump)
 
 
 class KernelDumpParser:

--- a/src/python/kdmp_parser/__init__.py
+++ b/src/python/kdmp_parser/__init__.py
@@ -27,6 +27,7 @@ class DumpType(enum.IntEnum):
     FullDump = _DumpType_t.FullDump
     KernelDump = _DumpType_t.KernelDump
     BMPDump = _DumpType_t.BMPDump
+    LiveKernelBitmapDump = _DumpType_t.LiveKernelBitmapDump
     MiniDump = _DumpType_t.MiniDump
     KernelMemoryDump = _DumpType_t.KernelMemoryDump
     KernelAndUserMemoryDump = _DumpType_t.KernelAndUserMemoryDump

--- a/src/python/kdmp_parser/__init__.py
+++ b/src/python/kdmp_parser/__init__.py
@@ -57,7 +57,7 @@ class KernelDumpParser:
         self.filepath = path
         self.context: __CONTEXT = self.__dump.GetContext()
         self.directory_table_base: int = self.__dump.GetDirectoryTableBase() & ~0xFFF
-        self.type = DumpType(self.__dump.GetDumpType())
+        self.type = DumpType(self.__dump.GetDumpType().value)
         self.header: __HEADER64 = self.__dump.GetDumpHeader()
         self.pages = _PageIterator(self.__dump)
         return

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -13,6 +13,11 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Assemblers",
     "Natural Language :: English",
 ]
@@ -37,4 +42,4 @@ test-command = "pytest {project}/tests"
 test-requires = "pytest"
 
 [tool.cibuildwheel.macos.environment]
-MACOSX_DEPLOYMENT_TARGET = "10.14"
+MACOSX_DEPLOYMENT_TARGET = "10.13"

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -29,11 +29,7 @@ wheel.py-api = "cp312"
 minimum-version = "0.4"
 build-dir = "build/{wheel_tag}"
 cmake.minimum-version = "3.20"
-cmake.args = [
-    "-DBUILD_PARSER:BOOL=OFF",
-    "-DBUILD_TESTS:BOOL=OFF",
-    "-DBUILD_PYTHON_PACKAGE:BOOL=ON",
-]
+cmake.args = ["-DBUILD_PYTHON_PACKAGE:BOOL=ON"]
 
 [tool.cibuildwheel]
 build-verbosity = 1

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "kdmp-parser"
-version = "0.7.2"
+version = "0.7.3"
 description = "A Cross-Platform C++ parser library for Windows kernel minidumps."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/python/src/kdmp_parser.cc
+++ b/src/python/src/kdmp_parser.cc
@@ -42,7 +42,6 @@ NB_MODULE(_kdmp_parser, m) {
       .value("FullDump", kdmpparser::DumpType_t::FullDump)
       .value("KernelDump", kdmpparser::DumpType_t::KernelDump)
       .value("BMPDump", kdmpparser::DumpType_t::BMPDump)
-
       .value("LiveKernelBitmapDump",
              kdmpparser::DumpType_t::LiveKernelBitmapDump)
       .value("MiniDump", kdmpparser::DumpType_t::MiniDump)

--- a/src/python/src/kdmp_parser.cc
+++ b/src/python/src/kdmp_parser.cc
@@ -82,8 +82,8 @@ NB_MODULE(_kdmp_parser, m) {
       .def_ro("TotalPresentPages", &kdmpparser::BMP_HEADER64::TotalPresentPages)
       .def_ro("Pages", &kdmpparser::BMP_HEADER64::Pages)
       .def_ro("Bitmap", &kdmpparser::BMP_HEADER64::Bitmap)
-      .def("Show", &kdmpparser::PHYSMEM_DESC::Show, "Prefix"_a)
-      .def("LooksGood", &kdmpparser::PHYSMEM_DESC::LooksGood);
+      .def("Show", &kdmpparser::BMP_HEADER64::Show, "Prefix"_a)
+      .def("LooksGood", &kdmpparser::BMP_HEADER64::LooksGood);
 
   nb::class_<kdmpparser::RDMP_HEADER64>(m, "RDMP_HEADER64")
       .def(nb::init<>())

--- a/src/python/src/kdmp_parser.cc
+++ b/src/python/src/kdmp_parser.cc
@@ -269,8 +269,8 @@ NB_MODULE(_kdmp_parser, m) {
 
                      return Hdr.u3.FullRdmpHeader;
                    })
-      .def("Show", &CONTEXT::Show, "Prefix"_a)
-      .def("LooksGood", &CONTEXT::LooksGood);
+      .def("Show", &HEADER64::Show, "Prefix"_a)
+      .def("LooksGood", &HEADER64::LooksGood);
 
   m.attr("PageSize") = kdmpparser::Page::Size;
   m.def("PageAlign", &kdmpparser::Page::Align, "Address"_a,

--- a/src/python/src/kdmp_parser.cc
+++ b/src/python/src/kdmp_parser.cc
@@ -43,6 +43,8 @@ NB_MODULE(_kdmp_parser, m) {
       .value("KernelDump", kdmpparser::DumpType_t::KernelDump)
       .value("BMPDump", kdmpparser::DumpType_t::BMPDump)
 
+      .value("LiveKernelBitmapDump",
+             kdmpparser::DumpType_t::LiveKernelBitmapDump)
       .value("MiniDump", kdmpparser::DumpType_t::MiniDump)
       .value("KernelMemoryDump", kdmpparser::DumpType_t::KernelMemoryDump)
       .value("KernelAndUserMemoryDump",

--- a/src/tests/tests_parser.cc
+++ b/src/tests/tests_parser.cc
@@ -176,7 +176,7 @@ constexpr TestCaseValues TestCaseCompleteDump{
 };
 
 constexpr TestCaseValues TestLiveKernelBitmapDump{
-    "FullLiveKernelMemory.dmp",
+    "fulllivekernelmemory.dmp",
     kdmpparser::DumpType_t::LiveKernelBitmapDump,
     0x154f5,
     0x0000000d96a9000, // cr3

--- a/src/tests/tests_parser.cc
+++ b/src/tests/tests_parser.cc
@@ -175,10 +175,36 @@ constexpr TestCaseValues TestCaseCompleteDump{
     0x00000000'0000001fULL,
 };
 
+constexpr TestCaseValues TestLiveKernelBitmapDump{
+    "FullLiveKernelMemory.dmp",
+    kdmpparser::DumpType_t::LiveKernelBitmapDump,
+    0x154f5,
+    0x0000000d96a9000, // cr3
+    {0x67, 0xd8, 0xb6, 0xdd, 0x00, 0x00, 0x00, 0x0a, 0x67, 0xa8, 0x1d, 0xd6,
+     0x00, 0x00, 0x00, 0x0a},
+    0x4ULL,
+    0xffffd20fd8553000ULL,
+    0xffffa1000ed84a00ULL,
+    0x0ULL,
+    0xffffd20fd3beeae0ULL,
+    0xfffff8074fb4b180ULL,
+    0xfffff80750a98b6dULL,
+    0xfffffd8d6bcaed10ULL,
+    0x0ULL,
+    0xb80ULL,
+    0xffffd20fd8553348ULL,
+    0x0ULL,
+    0xffffd20fd8553000ULL,
+    0x2ULL,
+    0x0ULL,
+    0xffffd20fd48d5080ULL,
+    0x1ULL,
+};
+
 constexpr std::array Testcases{
     TestCaseBmp,          TestCaseFull,
     TestCaseKernelDump,   TestCaseKernelUserDump,
-    TestCaseCompleteDump,
+    TestCaseCompleteDump, TestLiveKernelBitmapDump,
 };
 
 TEST_CASE("kdmp-parser", "parser") {


### PR DESCRIPTION
# Description

This PR adds support for "Live Kernel Memory" dump type (0x6), including Python API, and tests.

As indicated [here](https://github.com/0vercl0k/kdmp-parser/issues/26#issuecomment-2176323236) such dump can be generated as such:
![image](https://github.com/0vercl0k/kdmp-parser/assets/590234/43b95cd6-7b9c-4cb9-9de9-c15e25006707)

But is actually processed the same way as regular bmp dump:
![image](https://github.com/0vercl0k/kdmp-parser/assets/590234/06a78565-2e54-446a-b921-3d7720fa355d)

As a result, this PR only implements the type itself, and binds it to the "normal" BMP routine (i.e. `BuildPhysmemBMPDump`).

Fixes #26 
